### PR TITLE
Add Streamlit interface for text prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
-"# R-alit-augment-" 
+# R-alit-augment-
+
+Projet de sculpture virtuelle 3D utilisant des surfaces implicites.
+Ce dépôt propose une première base de code permettant de générer et visualiser
+des formes simples grâce à Python.
+
+## Prérequis
+
+- Python 3
+- `numpy`
+- `matplotlib`
+- `torch` (pour l'exemple d'IA)
+- `streamlit` (pour l'interface web)
+
+Installez les dépendances via :
+
+```bash
+pip install -r requirements.txt
+```
+
+## Utilisation
+
+Exécutez le script principal pour afficher un nuage de points représentant
+la union de deux sphères implicites :
+
+```bash
+python sculpture.py
+```
+
+Une fenêtre matplotlib s'ouvrira avec la représentation 3D.
+
+### Interaction immersive
+
+Le script `interactive_sculpture.py` permet de modifier en temps réel le
+rayon de deux sphères dont on affiche l'union.
+
+```bash
+python interactive_sculpture.py
+```
+
+### Interface Streamlit
+
+Un petit exemple d'application web permet de saisir un prompt textuel pour
+afficher la surface correspondante.
+
+```bash
+streamlit run streamlit_app.py
+```
+
+### Démonstration de l'intégration de l'IA
+
+Le script `neural_sdf.py` montre comment entraîner un réseau de neurones
+pour approximer la surface implicite d'une sphère. Utilisez l'option
+`--complex` pour activer un modèle plus profond :
+
+```bash
+python neural_sdf.py [--complex]
+```
+
+Après quelques itérations d'entraînement, une nouvelle fenêtre s'affichera
+avec la surface prédite par le réseau.
+
+Ce projet n'est qu'une ébauche et pourra être étendu pour intégrer des
+fonctions plus avancées (combinaisons de surfaces, interactions immersives,
+intégration de modèles d'IA plus complexes, etc.).

--- a/interactive_sculpture.py
+++ b/interactive_sculpture.py
@@ -1,0 +1,42 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.widgets import Slider
+
+from sculpture import sphere, union
+
+
+def update(val):
+    r1 = slider1.val
+    r2 = slider2.val
+    s1 = sphere(radius=r1, center=(-0.5, 0, 0))
+    s2 = sphere(radius=r2, center=(0.5, 0, 0))
+    combined = union(s1, s2)
+    points = combined.sample(bounds, resolution=50)
+    scatter._offsets3d = (points[:, 0], points[:, 1], points[:, 2])
+    fig.canvas.draw_idle()
+
+
+if __name__ == "__main__":
+    bounds = [(-1.5, 1.5), (-1.5, 1.5), (-1.5, 1.5)]
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    plt.subplots_adjust(bottom=0.25)
+
+    s1 = sphere(radius=1.0, center=(-0.5, 0, 0))
+    s2 = sphere(radius=1.0, center=(0.5, 0, 0))
+    combined = union(s1, s2)
+    points = combined.sample(bounds, resolution=50)
+    scatter = ax.scatter(points[:, 0], points[:, 1], points[:, 2], s=1)
+    ax.set_title("Union interactive de deux sph\xE8res")
+
+    axcolor = 'lightgoldenrodyellow'
+    ax_r1 = plt.axes([0.25, 0.1, 0.65, 0.03], facecolor=axcolor)
+    ax_r2 = plt.axes([0.25, 0.05, 0.65, 0.03], facecolor=axcolor)
+
+    slider1 = Slider(ax_r1, 'Rayon 1', 0.1, 1.5, valinit=1.0)
+    slider2 = Slider(ax_r2, 'Rayon 2', 0.1, 1.5, valinit=1.0)
+
+    slider1.on_changed(update)
+    slider2.on_changed(update)
+
+    plt.show()

--- a/neural_sdf.py
+++ b/neural_sdf.py
@@ -1,0 +1,103 @@
+import numpy as np
+import torch
+import torch.nn as nn
+import matplotlib.pyplot as plt
+
+from sculpture import sphere
+
+
+def generate_dataset(surface_func, bounds, n_samples=10000):
+    """Generate random points and signed values using the given surface."""
+    x = np.random.uniform(bounds[0][0], bounds[0][1], n_samples)
+    y = np.random.uniform(bounds[1][0], bounds[1][1], n_samples)
+    z = np.random.uniform(bounds[2][0], bounds[2][1], n_samples)
+    X, Y, Z = np.stack([x, y, z], axis=1).T
+    values = surface_func(X, Y, Z)
+    points = np.vstack([x, y, z]).T
+    return points.astype(np.float32), values.astype(np.float32)[:, None]
+
+
+class SDFNetwork(nn.Module):
+    """Simple fully connected network."""
+
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(3, 64),
+            nn.ReLU(),
+            nn.Linear(64, 64),
+            nn.ReLU(),
+            nn.Linear(64, 1)
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+class ComplexSDFNetwork(nn.Module):
+    """Deeper network for more complex shapes."""
+
+    def __init__(self):
+        super().__init__()
+        layers = []
+        in_dim = 3
+        for _ in range(5):
+            layers.append(nn.Linear(in_dim, 128))
+            layers.append(nn.ReLU())
+            in_dim = 128
+        layers.append(nn.Linear(128, 1))
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, x):
+        return self.net(x)
+
+
+def train_sdf(surface_func, bounds, epochs=100, lr=1e-3, complex_model=False):
+    points, values = generate_dataset(surface_func, bounds)
+    model_cls = ComplexSDFNetwork if complex_model else SDFNetwork
+    model = model_cls()
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    loss_fn = nn.MSELoss()
+    inputs = torch.from_numpy(points)
+    targets = torch.from_numpy(values)
+
+    for epoch in range(epochs):
+        optimizer.zero_grad()
+        preds = model(inputs)
+        loss = loss_fn(preds, targets)
+        loss.backward()
+        optimizer.step()
+        if (epoch + 1) % 20 == 0:
+            print(f"Epoch {epoch+1}/{epochs} - Loss: {loss.item():.4f}")
+
+    return model
+
+
+def plot_sdf(model, bounds, resolution=50):
+    x = np.linspace(bounds[0][0], bounds[0][1], resolution)
+    y = np.linspace(bounds[1][0], bounds[1][1], resolution)
+    z = np.linspace(bounds[2][0], bounds[2][1], resolution)
+    X, Y, Z = np.meshgrid(x, y, z)
+    pts = np.vstack([X.ravel(), Y.ravel(), Z.ravel()]).T
+    with torch.no_grad():
+        sdf_vals = model(torch.from_numpy(pts.astype(np.float32))).numpy().reshape(X.shape)
+    mask = sdf_vals <= 0
+    points = np.vstack((X[mask], Y[mask], Z[mask])).T
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    ax.scatter(points[:, 0], points[:, 1], points[:, 2], s=1)
+    ax.set_title('Neural SDF surface')
+    plt.show()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Train a neural SDF")
+    parser.add_argument("--complex", action="store_true", help="use a deeper network")
+    args = parser.parse_args()
+
+    surf = sphere(radius=1.0)
+    bounds = [(-1.5, 1.5), (-1.5, 1.5), (-1.5, 1.5)]
+    model = train_sdf(surf.func, bounds, epochs=200, complex_model=args.complex)
+    plot_sdf(model, bounds, resolution=60)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+matplotlib
+
+torch
+streamlit

--- a/sculpture.py
+++ b/sculpture.py
@@ -1,0 +1,96 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401  # needed for projection='3d'
+
+class ImplicitSurface:
+    """Représente une surface implicite définie par une fonction F(x, y, z)."""
+
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, x, y, z):
+        """Evaluate the implicit function."""
+        return self.func(x, y, z)
+
+    def sample(self, bounds, resolution=50):
+        """Retourne un nuage de points appartenant à la surface."""
+        x = np.linspace(bounds[0][0], bounds[0][1], resolution)
+        y = np.linspace(bounds[1][0], bounds[1][1], resolution)
+        z = np.linspace(bounds[2][0], bounds[2][1], resolution)
+        X, Y, Z = np.meshgrid(x, y, z)
+        F = self.func(X, Y, Z)
+        points = np.vstack((X[F <= 0], Y[F <= 0], Z[F <= 0])).T
+        return points
+
+    def plot(self, bounds, resolution=50, show=True, ax=None):
+        """Affiche le nuage de points de la surface.
+
+        Parameters
+        ----------
+        bounds : list
+            Bornes [xmin,xmax], [ymin,ymax], [zmin,zmax].
+        resolution : int, optional
+            Nombre de points par axe.
+        show : bool, optional
+            Si True, appelle ``plt.show()``. Utile hors de Streamlit.
+        ax : matplotlib Axes, optional
+            Axe 3D existant dans lequel dessiner la surface.
+        """
+        points = self.sample(bounds, resolution)
+        if ax is None:
+            fig = plt.figure()
+            ax = fig.add_subplot(111, projection='3d')
+        else:
+            fig = ax.figure
+
+        ax.scatter(points[:, 0], points[:, 1], points[:, 2], s=1)
+        ax.set_xlabel('X')
+        ax.set_ylabel('Y')
+        ax.set_zlabel('Z')
+        ax.set_title('Surface implicite')
+        if show:
+            plt.show()
+        return fig
+
+
+def sphere(radius=1.0, center=(0.0, 0.0, 0.0)):
+    """Crée une surface implicite représentant une sphère."""
+    def f(x, y, z):
+        cx, cy, cz = center
+        return (x - cx) ** 2 + (y - cy) ** 2 + (z - cz) ** 2 - radius ** 2
+    return ImplicitSurface(f)
+
+
+def union(surf1: ImplicitSurface, surf2: ImplicitSurface) -> ImplicitSurface:
+    """Return the union of two implicit surfaces."""
+
+    def f(x, y, z):
+        return np.minimum(surf1(x, y, z), surf2(x, y, z))
+
+    return ImplicitSurface(f)
+
+
+def intersection(surf1: ImplicitSurface, surf2: ImplicitSurface) -> ImplicitSurface:
+    """Return the intersection of two implicit surfaces."""
+
+    def f(x, y, z):
+        return np.maximum(surf1(x, y, z), surf2(x, y, z))
+
+    return ImplicitSurface(f)
+
+
+def difference(surf1: ImplicitSurface, surf2: ImplicitSurface) -> ImplicitSurface:
+    """Return the difference of two implicit surfaces (surf1 minus surf2)."""
+
+    def f(x, y, z):
+        return np.maximum(surf1(x, y, z), -surf2(x, y, z))
+
+    return ImplicitSurface(f)
+
+
+if __name__ == "__main__":
+    sphere1 = sphere(radius=1.0, center=(-0.5, 0, 0))
+    sphere2 = sphere(radius=1.0, center=(0.5, 0, 0))
+    combined = union(sphere1, sphere2)
+    bounds = [(-1.5, 1.5), (-1.5, 1.5), (-1.5, 1.5)]
+    combined.plot(bounds, resolution=60)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,40 @@
+import streamlit as st
+import matplotlib.pyplot as plt
+from sculpture import (
+    sphere,
+    union,
+    intersection,
+    difference,
+    ImplicitSurface,
+)
+
+
+def parse_prompt(prompt: str) -> ImplicitSurface | None:
+    prompt = prompt.lower()
+    if "union" in prompt and "sphere" in prompt:
+        s1 = sphere(radius=1.0, center=(-0.5, 0, 0))
+        s2 = sphere(radius=1.0, center=(0.5, 0, 0))
+        return union(s1, s2)
+    if "intersection" in prompt and "sphere" in prompt:
+        s1 = sphere(radius=1.2, center=(-0.3, 0, 0))
+        s2 = sphere(radius=1.2, center=(0.3, 0, 0))
+        return intersection(s1, s2)
+    if "difference" in prompt and "sphere" in prompt:
+        s1 = sphere(radius=1.2)
+        s2 = sphere(radius=1.0, center=(0.4, 0, 0))
+        return difference(s1, s2)
+    if "sphere" in prompt:
+        return sphere(radius=1.0)
+    return None
+
+
+st.title("Sculpture virtuelle 3D")
+prompt = st.text_input("Entrez votre prompt", "sphere")
+
+surface = parse_prompt(prompt)
+if surface is None:
+    st.write("Prompt non reconnu. Essayez par exemple 'sphere', 'union de spheres', 'difference de spheres' ...")
+else:
+    bounds = [(-1.5, 1.5), (-1.5, 1.5), (-1.5, 1.5)]
+    fig = surface.plot(bounds, resolution=60, show=False)
+    st.pyplot(fig)


### PR DESCRIPTION
## Summary
- enable plotting without `plt.show` for Streamlit usage
- list `streamlit` in requirements
- document how to launch the new Streamlit web app
- provide `streamlit_app.py` to turn text prompts into 3D shapes

## Testing
- `python -m py_compile sculpture.py neural_sdf.py interactive_sculpture.py streamlit_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857bb57d7a4832eb50e80c321d7b275